### PR TITLE
Fix JENKINS-12601: allow isSystem tag to exist in klocwork result output...

### DIFF
--- a/src/main/resources/com/thalesgroup/hudson/plugins/klocwork/model/xsd/klocwork-9.2.xsd
+++ b/src/main/resources/com/thalesgroup/hudson/plugins/klocwork/model/xsd/klocwork-9.2.xsd
@@ -71,6 +71,7 @@
 
     <!-- Mandatory tags -->
     <xs:element name="problemID" type="xs:int"/>
+    <xs:element name="isSystem" type="xs:string"/>
     <xs:element name="file" type="xs:string"/>
     <xs:element name="method" type="xs:string"/>
     <xs:element name="line" type="xs:int"/>
@@ -167,6 +168,7 @@
         <xs:complexType>
             <xs:all>
                 <xs:element ref="tag:problemID"/>
+                <xs:element ref="tag:isSystem" minOccurs="0"/>
                 <xs:element ref="tag:file"/>
                 <xs:element ref="tag:method"/>
                 <xs:element ref="tag:line"/>

--- a/src/test/java/com/thalesgroup/hudson/plugins/klocwork/KlocworkParserTest.java
+++ b/src/test/java/com/thalesgroup/hudson/plugins/klocwork/KlocworkParserTest.java
@@ -93,6 +93,7 @@ public class KlocworkParserTest {
     public void testCsvToSQLProject() {
         analyzeFiles("report-csvtosql.xml", 66, 18);
         analyzeFiles("bug-jenkins-10735.xml", 1, 0);
+        analyzeFiles("bug-jenkins-12601-parse-isSystem.xml", 1, 0);
     }
     //TO BE COMPLETED (with other files to test)...
 }

--- a/src/test/resources/com/thalesgroup/hudson/plugins/klocwork/bug-jenkins-12601-parse-isSystem.xml
+++ b/src/test/resources/com/thalesgroup/hudson/plugins/klocwork/bug-jenkins-12601-parse-isSystem.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<errorList xmlns="http://www.klocwork.com/inForce/report/1.0">
+<problem>
+ <problemID>2</problemID>
+ <isSystem>true</isSystem>
+ <file>C:\Jenkins_Home\jobs\NUnit Quick Learning\workspace\NUnit_Quick_Learn_1\AccountTest.cs</file>
+ <method>AccountTest.cs</method>
+ <line>64</line>
+ <column>20</column>
+ <code>CS.FLOAT.EQCHECK</code>
+ <message>Equality check on floating point type</message>
+ <anchor>0</anchor>
+ <prefix>result=0;doublestep=(x2-x1)/700;</prefix>
+ <postfix>{result=result+x*step;x=x+step;b</postfix>
+ <citingStatus>Analyze</citingStatus>
+ <severity>Style</severity>
+ <severitylevel>8</severitylevel>
+ <displayAs>Warning</displayAs>
+ <taxonomies>
+  <taxonomy name="C#" metaInf=""/>
+ </taxonomies>
+</problem>
+</errorList>


### PR DESCRIPTION
For a while now, I have implemented a fix for jenkins issue 12601 in my personal repository.

We see that in some occasions klocwork emits an "isSystem" tag in its xml output, which the current klocwork plugin is unable to parse/ignore.  This if fixed with this code change.

I already added a patch for it to the jenkins bugtracker, but did not found time reformat it as a github pull request.  So here it is.  Let me know what you think of it.

....

Signed-off-by: Steven Aerts steven.aerts@gmail.com
