### PR TITLE
FIX JENKINS-12535: Link to the line which contains the error instead of just linking to the...

### DIFF
--- a/src/main/resources/com/thalesgroup/hudson/plugins/klocwork/KloResult/summary.jelly
+++ b/src/main/resources/com/thalesgroup/hudson/plugins/klocwork/KloResult/summary.jelly
@@ -53,7 +53,7 @@
                      ${kloFile.fileNameOnly}
                 </j:if>
                 <j:if test="${not elt.isSourceIgnored()}">
-                      <a href="source.${kloFile.key}">${kloFile.fileNameOnly}</a>
+                      <a href="source.${kloFile.key}?#${kloFile.line}">${kloFile.fileNameOnly}</a>
                 </j:if>
 
 


### PR DESCRIPTION
For a while now, I have implemented a nice handy feature in my personal repository.

When you follow a klocwork issue from the overview you are currently directed to the page where the manifests itself, and there you have scroll to/find the issue yourself.  With this patch you not only jump to the right file, you also jump to the right line where the issue is detected.

This is also tracked by JENKINS-12535 which contains the same patch for this feature as this pull request.
....

Signed-off-by: Steven Aerts steven.aerts@gmail.com
