### PR TITLE
Bug fix for Post-Klocwork step where query was incorrectly formatted and caused errors.

### DIFF
--- a/src/main/java/com/emenda/klocwork/util/KlocworkUtil.java
+++ b/src/main/java/com/emenda/klocwork/util/KlocworkUtil.java
@@ -390,11 +390,14 @@ public class KlocworkUtil {
         String request = "action=" + action + "&project=" + envVars.get(KlocworkConstants.KLOCWORK_PROJECT);
         if (!StringUtils.isEmpty(query)) {
             try {
-				//Build the request, applying grouping:off (unless query contains grouping:on)
-                request += "&query=" +
-                    KlocworkUtil.getQueryDefaultGroupingOff(query) + query;
-				//Encode the request in UTF-8
-                request = URLEncoder.encode(request, "UTF-8");
+                request += "&query=";
+				//Build the query value
+				String queryEncoded = KlocworkUtil.getQueryDefaultGroupingOff(query);
+                queryEncoded += query;
+				//Encode the query value
+				queryEncoded = URLEncoder.encode(queryEncoded, "UTF-8");
+				//Add the query value to the request
+                request += queryEncoded;
             } catch (UnsupportedEncodingException ex) {
                 throw new AbortException(ex.getMessage());
             }

--- a/src/main/java/com/emenda/klocwork/util/KlocworkUtil.java
+++ b/src/main/java/com/emenda/klocwork/util/KlocworkUtil.java
@@ -391,8 +391,8 @@ public class KlocworkUtil {
         if (!StringUtils.isEmpty(query)) {
             try {
                 request += "&query=" +
-                    KlocworkUtil.getQueryDefaultGroupingOff(query);
-                request += URLEncoder.encode(query, "UTF-8");
+                    KlocworkUtil.getQueryDefaultGroupingOff(query) + query;
+                request += URLEncoder.encode(request, "UTF-8");
             } catch (UnsupportedEncodingException ex) {
                 throw new AbortException(ex.getMessage());
             }

--- a/src/main/java/com/emenda/klocwork/util/KlocworkUtil.java
+++ b/src/main/java/com/emenda/klocwork/util/KlocworkUtil.java
@@ -391,12 +391,12 @@ public class KlocworkUtil {
         if (!StringUtils.isEmpty(query)) {
             try {
                 request += "&query=";
-				//Build the query value
-				String queryEncoded = KlocworkUtil.getQueryDefaultGroupingOff(query);
+                //Build the query value
+                String queryEncoded = KlocworkUtil.getQueryDefaultGroupingOff(query);
                 queryEncoded += query;
-				//Encode the query value
-				queryEncoded = URLEncoder.encode(queryEncoded, "UTF-8");
-				//Add the query value to the request
+                //Encode the query value
+                queryEncoded = URLEncoder.encode(queryEncoded, "UTF-8");
+                //Add the query value to the request
                 request += queryEncoded;
             } catch (UnsupportedEncodingException ex) {
                 throw new AbortException(ex.getMessage());

--- a/src/main/java/com/emenda/klocwork/util/KlocworkUtil.java
+++ b/src/main/java/com/emenda/klocwork/util/KlocworkUtil.java
@@ -421,9 +421,9 @@ public class KlocworkUtil {
     private static String getQueryDefaultGroupingOff(String query) {
         if(!query.toLowerCase().contains("grouping:off")
                 && !query.toLowerCase().contains("grouping:on")){
-            return query += "grouping:off";
+            return "grouping:off ";
         }
-        return query;
+        return "";
     }
 
 }

--- a/src/main/java/com/emenda/klocwork/util/KlocworkUtil.java
+++ b/src/main/java/com/emenda/klocwork/util/KlocworkUtil.java
@@ -390,9 +390,11 @@ public class KlocworkUtil {
         String request = "action=" + action + "&project=" + envVars.get(KlocworkConstants.KLOCWORK_PROJECT);
         if (!StringUtils.isEmpty(query)) {
             try {
+				//Build the request, applying grouping:off (unless query contains grouping:on)
                 request += "&query=" +
                     KlocworkUtil.getQueryDefaultGroupingOff(query) + query;
-                request += URLEncoder.encode(request, "UTF-8");
+				//Encode the request in UTF-8
+                request = URLEncoder.encode(request, "UTF-8");
             } catch (UnsupportedEncodingException ex) {
                 throw new AbortException(ex.getMessage());
             }


### PR DESCRIPTION
Users reported errors in the Post-build step "Klocwork Gateway". The query string sent to the server was being incorrectly formatted due to errors in the code.