### PR TITLE
Fix conflicting "window.onload" usage

### DIFF
--- a/src/main/resources/com/klocwork/kwjenkinsplugin/KlocworkProjectAction/floatingBox.jelly
+++ b/src/main/resources/com/klocwork/kwjenkinsplugin/KlocworkProjectAction/floatingBox.jelly
@@ -14,9 +14,9 @@
 
         <script type="text/javascript" src="${rootURL}/plugin/klocwork/js/KlocworkTrendChart.js"></script>
         <script>
-            window.onload = function () {
+            Behaviour.addLoadEvent(function () {
                 renderChart(${action.chartData})
-            }
+            });
         </script>
     </j:if>
 </j:jelly>


### PR DESCRIPTION
The `Behaviour` object from Jenkins webapp already uses `window.onload` for setting up some HTML elements. This plugin overrides that function, which causes some elements to misbehave (for example, the "Build Now" button is using GET requests instead of POST).

The commit fixes the issue by using `Behaviour.addLoadEvent()` instead (it's fine here because `behavior.js` is loaded in `<head>` element).
